### PR TITLE
HomeKit Audio Receiver support and docs update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright © 2016-2023 author of https://github.com/stfnhmplr/homebridge-denon-marantz-avr and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,73 @@
-**DEPRACATED see: https://github.com/moifort/homebridge-denon**
+# homebridge-denon-marantz-avr
 
-# Homebridge Denon Marrantz
+homebridge-plugin for Denon and Marantz AVR control with Apple-Homekit. Works with most Denon AVR since 2011, supports a second zone and implements the speaker service with Audio Receiver (AVR) characteristic.
 
-homebridge-plugin for Denon and Marantz AVR control with Apple-Homekit. Works with most Denon AVR since 2011, supports a second zone and implements the speaker service.
+## Installation
 
-# Why V2?
+Follow standard installation via Homebridge UI **or** follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for the Homebridge server installation. The plugin is published through [NPM](https://www.npmjs.com/package/homebridge-denon) and should be installed "globally" by typing:
 
-I add `defaultVolume` and `defaultInput` parameters so when you turn on it's set a default parameter
-
-# Installation
-Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for the homebridge server installation. The plugin is published through [NPM](https://www.npmjs.com/package/homebridge-denon) and should be installed "globally" by typing:
-
-    sudo npm install -g homebridge-denon-v2
-
-# Configuration
-
-config.json
-
-Example:
+```bash
+sudo npm install -g homebridge-denon-marantz-avr 
 ```
+
+## Configuration
+
+Example `platforms` section for DRA-N4 (with customized inputs):
+
+```json
 {
-    "bridge": {
-        "name": "Homebridge",
-        "username": "CC:22:3D:E3:CE:30",
-        "port": 51826,
-        "pin": "123-45-678"
-    },
-
-    "description": "just an example config",
-
-    "platforms": [
+  "platforms": [
+    {
+      "platform": "denon-marantz-avr",
+      "accessories": [
         {
-          "platform": "DenonMarantzAVR",
-          "name": "Denon LivingRoom",
-          "host": "192.168.178.85",
-          "maxVolume": 100,
-          "defaultVolume": 35,
-          "defaultInput": "DVD",
-          "secondZone": true
+          "uniqueId": "DenonMarantzAVR",
+          "displayName": "DENON Ceol Piccolo",
+          "ip": "192.168.1.2",
+          "maxVolume": 50,
+          "defaultVolume": 10,
+          "defaultInput": "ANALOGIN",
+          "availableInputs": [
+            "ANALOGIN",
+            "DIGITALIN1"
+          ],
+          "zone2enabled": false
         }
-    ]
+      ]
+    }
+  ],
 }
 ```
 
-### notes
-If you are interested in setting the volume of your receiver with Siri than [this](https://github.com/robertvorthman/homebridge-marantz-volume) plugin might be a good addition. Only remember to not tell Siri "Set the light in the Living room to 100 %" ;)
-homebridge-marantz-volume was written by Robert Vorthman (thanks!)
+## Usage in Home app
+
+TVs and AVRs are required by HAP to be exposed as separate devices. Therefore, after usual Homekit pairing of Homebridge bridge you need to do the following in Home app:
+
+- click `+` and select *Add Accessory*
+- click *More options...*
+- select device with AVR icon and name matching `displayName` from the config
+- enter PIN that you chose for the bridge (either main Homebridge or plugin-dedicated)
+
+Inputs and power can be controlled from Home app. For volume and up/down/left/right/select buttons, you must use *Apple TV remote* app and switch to AVR from top menu.
+
+## Caveat about volume control
+
+Unfortunately, even Audio Receiver device category in HomeKit (added in R3? R2 is latest "open-source") can't control volume using Home automation, Siri or tvOS. In other words, while neat, HomeKit can't be used to link AppleTV with Denon AVRs that don't support HDMI-CEC (e.g. ones without HDMI and connect over HDMI audio extractors). 
+
+As a workaround you can set the following in Apple TV in section *Settings* - *Remotes and Devices* - *Home Cinema Control* - *Select Volume Control*:
+
+- remove all IR remotes
+- switch option to *Auto*
+- confirm in upper level menu it says `Auto (Off)`
+
+
+That way, Siri Remote volume buttons somehow still send IR signals that are understood by some Denon AVRs (incl. DRA-N4), so you can control AVR volume.
+
+Additionaly, iOS *Control Other Speakers & TVs* in Control Center and in media streaming (AirPlay or Apple Music remote) can control tvOS volume as well (on normal equipment it'd be equal to headphone volume setting as audio over HDMI is like line level). With ability to use *Apple TV remote* app to set output AVR levels it's *semi-competent* HDMI-CEC volume control replacement.
+
+
+## References
+
+- DENON AVR control protocol - http://assets.eu.denon.com/DocumentMaster/DE/AVR1713_AVR1613_PROTOCOL_V8.6.0.pdf
+- DENON SYSTEM control protocol - http://assets.eu.denon.com/DocumentMaster/DE/DRAN5_RCDN8_PROTOCOL_V.1.0.0.pdf
+- Apple HomeKit Accessory Protocol (HAP) - https://developer.apple.com/apple-home/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-denon-v3",
-    "version": "1.0.15",
+    "version": "1.0.52",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-denon-v3",
-            "version": "1.0.15",
+            "version": "1.0.52",
             "license": "MIT",
             "dependencies": {
                 "telnet-client": "^1.4.9"
@@ -18,7 +18,8 @@
                 "typescript": "^4.2.4"
             },
             "engines": {
-                "homebridge": ">=1.0.0"
+                "homebridge": ">=1.0.0",
+                "node": ">=10.17.0"
             }
         },
         "node_modules/@homebridge/ciao": {

--- a/package.json
+++ b/package.json
@@ -1,48 +1,50 @@
 {
-    "name": "homebridge-denon-v3",
-    "version": "1.0.52",
-    "description": "Denon and Marantz AVR support for Homebridge: https://github.com/nfarina/homebridge",
-    "license": "MIT",
-    "keywords": [
-        "homebridge-plugin",
-        "Denon",
-        "Marantz"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/thebeastxdxd/homebridge-denon-marantz-avr.git"
-    },
-    "bugs": {
-        "url": "http://github.com/thebeastxdxd/homebridge-denon-marantz-avr/issues"
-    },
-    "engines": {
-        "node": ">=10.17.0",
-        "homebridge": ">=1.0.0"
-    },
-    "main": "dist/index.js",
-    "files": [
-        "dist"
-    ],
-    "dependencies": {
-        "telnet-client": "^1.4.9"
-    },
-    "devDependencies": {
-        "@types/node": "^10.17.19",
-        "homebridge": "^1.0.4",
-        "rimraf": "^3.0.2",
-        "typescript": "^4.2.4"
-    },
-    "scripts": {
-        "clean": "rimraf ./dist",
-        "build": "rimraf ./dist && tsc",
-        "prepublishOnly": "npm run build",
-        "postpublish": "npm run clean",
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "prettier": {
-        "singleQuote": true,
-        "tabWidth": 4,
-        "trailingComma": true,
-        "printWidth": 100
-    }
+  "name": "homebridge-denon-marantz-avr",
+  "version": "1.1.0",
+  "description": "Denon and Marantz AVR support for Homebridge: https://github.com/nfarina/homebridge",
+  "license": "MIT",
+  "keywords": [
+    "homebridge-plugin",
+    "Denon",
+    "Marantz",
+    "avr",
+    "audio-receiver"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/thebeastxdxd/homebridge-denon-marantz-avr.git"
+  },
+  "bugs": {
+    "url": "http://github.com/thebeastxdxd/homebridge-denon-marantz-avr/issues"
+  },
+  "engines": {
+    "node": ">=10.17.0",
+    "homebridge": ">=1.0.0"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "telnet-client": "^1.4.9"
+  },
+  "devDependencies": {
+    "@types/node": "^10.17.19",
+    "homebridge": "^1.0.4",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.2.4"
+  },
+  "scripts": {
+    "clean": "rimraf ./dist",
+    "build": "rimraf ./dist && tsc",
+    "prepublishOnly": "npm run build",
+    "postpublish": "npm run clean",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "trailingComma": true,
+    "printWidth": 100
+  }
 }

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -41,6 +41,12 @@ export class DenonMarantzAVRAccessory {
         this.accessory
             .getService(this.platform.Service.AccessoryInformation)!
             .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Denon/Marantz')
+            .setCharacteristic(this.platform.Characteristic.Model, 'TBD')
+            .setCharacteristic(this.platform.Characteristic.SerialNumber, 'TBD')
+            .setCharacteristic(
+              this.platform.Characteristic.FirmwareRevision,
+              `${this.accessory.context.device.firmwareVersion}`,
+            );
 
         this.log.info("adding television service")
         this.service = this.accessory.getService(this.platform.Service.Television) || this.accessory.addService(this.platform.Service.Television);
@@ -48,11 +54,11 @@ export class DenonMarantzAVRAccessory {
         this.init();
 
         // regularly ping the AVR to keep power/input state syncronised
-        setInterval(this.updateAVRState.bind(this), 60000);
+        setInterval(this.updateAVRState.bind(this), 10000);
     }
 
     async init() {
-        try {
+      try {
             await this.updateInputSources();
             await this.createTVService();
             await this.createTVSpeakerService();
@@ -72,7 +78,7 @@ export class DenonMarantzAVRAccessory {
         this.log.info("display name is ", this.accessory.context.device.display)
         this.service
             .setCharacteristic(this.platform.Characteristic.Name, this.accessory.context.device.displayName)
-            // .setCharacteristic(this.platform.Characteristic.ConfiguredName, this.accessory.context.device.displayName)
+            .setCharacteristic(this.platform.Characteristic.ConfiguredName, this.accessory.context.device.displayName)
             .setCharacteristic(
                 this.platform.Characteristic.SleepDiscoveryMode,
                 this.platform.Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE,
@@ -127,7 +133,7 @@ export class DenonMarantzAVRAccessory {
                 inputService
                     .setCharacteristic(this.platform.Characteristic.Identifier, i)
                     .setCharacteristic(this.platform.Characteristic.ConfiguredName, input)
-                    .setCharacteristic(this.platform.Characteristic.Name, `${this.accessory.context.device.displayName} input ${input}`)
+                    .setCharacteristic(this.platform.Characteristic.Name, `${this.accessory.context.device.displayName} ${input}`)
                     .setCharacteristic(
                         this.platform.Characteristic.IsConfigured,
                         this.platform.Characteristic.IsConfigured.CONFIGURED,
@@ -138,11 +144,11 @@ export class DenonMarantzAVRAccessory {
                     )
                     .setCharacteristic(
                         this.platform.Characteristic.InputSourceType,
-                        this.platform.Characteristic.InputSourceType.APPLICATION,
+                        this.platform.Characteristic.InputSourceType.HOME_SCREEN,
                     )
                     .setCharacteristic(
                         this.platform.Characteristic.InputDeviceType,
-                        this.platform.Characteristic.InputDeviceType.TV,
+                        this.platform.Characteristic.InputDeviceType.OTHER,
                     );
 
 
@@ -228,7 +234,7 @@ export class DenonMarantzAVRAccessory {
     async setVolumeSelector(direction: CharacteristicValue) {
         try {
             const currentVolume = Number(this.controller.GetVolume(this.zone));
-            const volumeStep = 5;
+            const volumeStep = 1; // TODO: handle volume step in config
 
             if (direction === this.platform.Characteristic.VolumeSelector.INCREMENT) {
                 this.platform.log.info('Volume Up', currentVolume + volumeStep);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -8,6 +8,7 @@ function msleep(n: number) {
 
 const serverControllerPort = 23
 
+// TODO: replace with REST API (HTTP)
 
 export class DenonMarantzController {
     private serverController: telnet_client;
@@ -266,7 +267,7 @@ export class DenonMarantzController {
             value = this.maxVol;
         }
         if ((Number(value) * 10) % 10) {
-            value = 5 * Math.round(Number(value) * 10 / 5)
+            value = 1 * Math.round(Number(value) * 10 / 1) // TODO: handle volume step in config
         }
         let commandPrefix = `${this.getPrefixByZone(zone)}MV${value}`;
         await this.serverControllerSend(commandPrefix)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ import { DenonMarantzAVRPlatform } from './platform';
 export default (api: API) => {
   api.registerPlatform(PLATFORM_NAME, DenonMarantzAVRPlatform);
 };
+
+// TODO: UI settings

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -10,9 +10,7 @@ import {
 
 import { DenonMarantzAVRAccessory } from './accessory';
 import { DenonMarantzController } from './controller';
-//   import { YamahaVolumeAccessory } from './volumeAccessory.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
-//   import { YamahaPureDirectAccessory } from './pureDirectAccessory.js';
 
 interface DenonMarantzAccessoryConfig {
     uniqueId: string;
@@ -33,7 +31,7 @@ export class DenonMarantzAVRPlatform implements IndependentPlatformPlugin {
     public readonly Service: typeof Service = this.api.hap.Service;
     public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
     public readonly platformAccessories: PlatformAccessory[] = [];
-    // public readonly externalAccessories: PlatformAccessory[] = [];
+    public readonly externalAccessories: PlatformAccessory[] = [];
 
     constructor(public readonly log: Logging, public readonly config: PlatformConfig, public readonly api: API) {
         this.log.debug('Finished initializing platform:', this.config.name);
@@ -49,48 +47,11 @@ export class DenonMarantzAVRPlatform implements IndependentPlatformPlugin {
     }
 
     async discoverAVR() {
-        //   try {
-        //     const baseApiUrl = `http://${this.config.ip}/YamahaExtendedControl/v1`;
-        //     const deviceInfoResponse = await fetch(`${baseApiUrl}/system/getDeviceInfo`);
-        //     const deviceInfo = (await deviceInfoResponse.json()) as DeviceInfo;
-
-        //     const featuresResponse = await fetch(`${baseApiUrl}/system/getFeatures`);
-        //     const features = (await featuresResponse.json()) as Features;
-
-        //     if (deviceInfo.response_code !== 0) {
-        //       throw new Error();
-        //     }
-
-        //     const device: AccessoryContext['device'] = {
-        //       displayName: this.config.name ?? `Yamaha ${deviceInfo.model_name}`,
-        //       modelName: deviceInfo.model_name,
-        //       systemId: deviceInfo.system_id,
-        //       firmwareVersion: deviceInfo.system_version,
-        //       baseApiUrl,
-        //     };
-
-        //     if (this.config.enablePureDirectSwitch) {
-        //       await this.createPureDirectAccessory(device);
-        //     }
-
-        //     await this.createZoneAccessories(device, 'main');
-
-        //     features.zone.length > 1 && (await this.createZoneAccessories(device, 'zone2'));
-        //     features.zone.length > 2 && (await this.createZoneAccessories(device, 'zone3'));
-        //     features.zone.length > 3 && (await this.createZoneAccessories(device, 'zone4'));
-
-        //     if (this.externalAccessories.length > 0) {
-        //       this.api.publishExternalAccessories(PLUGIN_NAME, this.externalAccessories);
-        //     }
-        //   } catch {
-        //     this.log.error(`
-        //       Failed to get system config from ${this.config.name}. Please verify the AVR is connected and accessible at ${this.config.ip}
-        //     `);
-        //   }
-        // loop over the discovered devices and register each one if it has not already been registered
+  
+      require('events').EventEmitter.prototype._maxListeners = 50;
+      
         for (const device of (<DenonMarantzConfig>this.config).accessories) {
             await this.createZoneAccessories(device);
-
         }
 
     }
@@ -98,14 +59,15 @@ export class DenonMarantzAVRPlatform implements IndependentPlatformPlugin {
     async createZoneAccessories(device: DenonMarantzAccessoryConfig) {
 
         let controller = new DenonMarantzController(this.log, device.ip);
-        await this.createAVRAccessory(device, controller, 'main');
-
-        //   await this.createVolumeAccessory(device, 'main');
+        const avrAccessoryMain = await this.createAVRAccessory(device, controller, 'main');
+        this.externalAccessories.push(avrAccessoryMain);
 
         if (device.zone2enabled) {
-            await this.createAVRAccessory(device, controller, 'zone2');
-            // await this.createVolumeAccessory(device, 'zone2');
+          const avrAccessoryZone2 = await this.createAVRAccessory(device, controller, 'zone2');
+          this.externalAccessories.push(avrAccessoryZone2);
         }
+
+        this.api.publishExternalAccessories(PLUGIN_NAME, this.externalAccessories); // strictly required for AVR or TV to be shown
     }
 
     async createAVRAccessory(device: DenonMarantzAccessoryConfig, controller: DenonMarantzController, zone: string) {
@@ -116,8 +78,8 @@ export class DenonMarantzAVRPlatform implements IndependentPlatformPlugin {
         if (existingAccessory) {
             this.log.info(`restoring from cache ${device.displayName}, with ip ${device.ip}`)
             new DenonMarantzAVRAccessory(this.log, this, existingAccessory, zone, controller);
-        } else {
-
+            return existingAccessory;
+        } else {~
             this.log.info(`adding accessory ${device.displayName}, with ip ${device.ip}`)
 
             const accessory = new this.api.platformAccessory(
@@ -130,51 +92,7 @@ export class DenonMarantzAVRPlatform implements IndependentPlatformPlugin {
 
             new DenonMarantzAVRAccessory(this.log, this, accessory, zone, controller);
 
-            this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
             return accessory;
         }
     }
-
-    // async createVolumeAccessory(device: AccessoryContext['device'], zone: Zone['id']): Promise<void> {
-    //   let uuid = `${device.ip}_${zone}_volume`;
-    //   uuid = this.api.hap.uuid.generate(uuid);
-
-    //   const accessory = new this.api.platformAccessory<AccessoryContext>(
-    //     `AVR Vol. ${zone}`,
-    //     uuid,
-    //     this.api.hap.Categories.FAN,
-    //   );
-
-    //   accessory.context = { device };
-
-    //   new DenonMarantzVolumeAccessory(this, accessory, zone);
-
-    //   const existingAccessory = this.platformAccessories.find((accessory) => accessory.UUID === uuid);
-    //   if (existingAccessory) {
-    //     this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
-    //   }
-
-    //   this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
-    // }
-
-    // async createPureDirectAccessory(device: AccessoryContext['device']): Promise<void> {
-    //   const uuid = this.api.hap.uuid.generate(`${device.systemId}_${this.config.ip}_pureDirect`);
-
-    //   const accessory = new this.api.platformAccessory<AccessoryContext>(
-    //     'AVR Pure Direct',
-    //     uuid,
-    //     this.api.hap.Categories.SWITCH,
-    //   );
-
-    //   accessory.context = { device };
-
-    //   new YamahaPureDirectAccessory(this, accessory);
-
-    //   const existingAccessory = this.platformAccessories.find((accessory) => accessory.UUID === uuid);
-    //   if (existingAccessory) {
-    //     this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
-    //   }
-
-    //   this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
-    // }
 }


### PR DESCRIPTION
- tweak some HAP characteristics and volume step
- change how accessory is exposed - required for AVR to work in HomeKit (othewrwise it shows as TV)
- clean-up ancient README.md and add LICENSE file after 7 years
- clean-up code forked from https://github.com/ACDR/homebridge-yamaha-avr